### PR TITLE
Fix: cannot get list parameters of GET request

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -483,6 +483,9 @@ class RequestHandler(object):
             if default is self._ARG_DEFAULT:
                 raise MissingArgumentError(name)
             return default
+        # return a list if request send a list like `l1=a&l1=b`
+        if len(args) > 1:
+            return args
         return args[-1]
 
     def _get_arguments(self, name, source, strip=True):


### PR DESCRIPTION
request of GET method can pass a list parameters through:

`http://url?list_key=val1&list_key=val2&list_key=val3`

When using `self.get_argument('list_key')` function, I can only get **one value** of the list for that function only get `args[-1]`.

Hope to be merged.